### PR TITLE
Add items show action

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,7 @@ gem 'devise'
 gem "pry-rails"
 gem 'active_hash'
 gem 'mini_magick'
+
+group :production do
+  gem 'rails_12factor'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,11 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (6.0.3.2)
       actionpack (= 6.0.3.2)
       activesupport (= 6.0.3.2)
@@ -277,6 +282,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails_12factor
   rspec-rails (~> 4.0.0.beta2)
   rubocop
   sass-rails (~> 5)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,14 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
+
+  private
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 
   protected
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,6 +16,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+    @user = User.find(@item.user_id)
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,6 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: [:show]
+
   def index
     @items = Item.all
   end
@@ -17,8 +19,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
-    @user = User.find(@item.user_id)
   end
 
   private
@@ -36,5 +36,9 @@ class ItemsController < ApplicationController
       :price,
       :user_id
     ).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -119,7 +119,7 @@
 
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "" %>
+        <%= link_to(item_path(item.id)) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
@@ -141,6 +141,7 @@
             </div>
           </div>
         </div>
+        <% end %>
       </li>
     <% end %>
     </ul>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,11 +7,11 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image, class: "item-box-img" %>
-      <% if @item.user_id = nil %>
+      
       <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
-      <% end %>
+       </div>
+      
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -22,7 +22,7 @@
       </span>
     </div>
 
-  <% if current_user == @user %>
+  <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
@@ -36,7 +36,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @user.nickname %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -3,58 +3,60 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class: "item-box-img" %>
+      <% if @item.user_id = nil %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
       </span>
     </div>
 
-
+  <% if current_user == @user %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+  <% elsif user_signed_in? %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-
+  <% end %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.introduction %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage_payer.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture_code.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.preparation_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/db/migrate/20200721032936_remove_image_from_items.rb
+++ b/db/migrate/20200721032936_remove_image_from_items.rb
@@ -1,5 +1,0 @@
-class RemoveImageFromItems < ActiveRecord::Migration[6.0]
-  def change
-    remove_column :items, :image, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,7 +45,6 @@ ActiveRecord::Schema.define(version: 2020_07_20_063304) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "image"
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_21_032936) do
+ActiveRecord::Schema.define(version: 2020_07_20_063304) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2020_07_21_032936) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "image"
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 


### PR DESCRIPTION
# WHY
①ユーザーが予め商品詳細を把握することで購入のミスマッチを防ぐためです。

# WHAT
商品詳細表示の実装を行いました。
①[ログアウト](https://gyazo.com/d9b206c23cf7f956b2dc4cb5a260db69)した状態でも商品詳細にリンク出来る実装です。(編集・削除・購入のボタンはログアウトユーザーには表示しない)
②[出品者](https://gyazo.com/c3b4227717360cc4c416b2ae1c4927bf)にしか商品の編集・削除のリンク出来ない実装です。(購入ボタンの表示はしない)
③[出品者以外（且つログインしたユーザー）](https://gyazo.com/3b3c5fa92c7afffe7706b78b36432a90)のみ商品購入のリンク出来る実装です。(編集・削除ボタンは表示しない）
今回のケースは"furima太郎"が"太郎furima"の商品を閲覧しているケースです。