### PR TITLE
add_items_edit_action

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -32,7 +32,6 @@ class ItemsController < ApplicationController
     end
   end
 
-
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:show]
+  before_action :set_item, only: [:show, :edit, :update]
 
   def index
     @items = Item.all
@@ -20,6 +20,18 @@ class ItemsController < ApplicationController
 
   def show
   end
+
+  def edit
+  end
+
+  def update
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
+  end
+
 
   private
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -5,9 +5,9 @@
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
-    <% render 'shared/error_messages', model: f.object%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     
     <div class="img-upload">
@@ -28,13 +28,13 @@
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :introduction, class:"items-text", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
 
@@ -45,12 +45,12 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, { }, {class: "select-box"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"}) %>
+        <%= f.collection_select(:item_condition_id, ItemCondition.all, :id, :name, { }, {class:"select-box"}) %>
       </div>
     </div>
 
@@ -64,17 +64,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"}) %>
+        <%= f.collection_select(:postage_payer_id, PostagePayer.all, :id, :name, { }, {class:"select-box"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"}) %>
+        <%= f.collection_select(:prefecture_code_id, PrefectureCode.all, :id, :name, { }, {class:"select-box"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box"}) %>
+        <%= f.collection_select(:preparation_day_id, PreparationDay.all, :id, :name, { }, {class:"select-box"}) %>
       </div>
     </div>
 
@@ -90,7 +90,7 @@
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -127,7 +127,7 @@
 
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
   </div>
   <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,7 @@
     </div>
 
   <% if user_signed_in? && current_user.id == @item.user_id %>
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
   <% elsif user_signed_in? %>


### PR DESCRIPTION
# WHY
①商品出品者が商品の編集を行うことで柔軟なユーザー対応を行うためです。

# WHAT
①商品情報（商品画像・商品名・商品の状態など）を変更できるようにしました。
[プログラミング教材からプロ](https://gyazo.com/8006ebbdb7b5142ff4430d107382da95)に変更しました。
②出品者だけが編集ページに遷移できるようにしました。
[furima太郎がfurima太郎の商品](https://gyazo.com/6d6fd7d9dac05c50a8dcf7c1a369766f)を編集出来ます。
[furima太郎が太郎furimaの商品](https://gyazo.com/2f7791e10bb1117913e5f87c63648f2e)に遷移した時は編集ボタンはないです。
③商品出品時とほぼ同じUIで編集機能が実装できるようにしました。
[商品出品時](https://gyazo.com/ba27e9376d38e7953693980fb5cc30a3)のUIがこちらです。
[編集画面時](https://gyazo.com/ba362e238cc1a0a9338ca7bce991df24)のUIがこちらです。
④画像やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で表示されるようにしました。
[編集ボタンで遷移後に文字](https://gyazo.com/37cb3ce305226958e9ba490c858a1d2a)が記入されています。
⑤エラーハンドリングができているように実装しました。
[エラー文](https://gyazo.com/9f30409d560e91b53f30306a5380d73a)を表示させました。